### PR TITLE
DatabaseTestingExtension: remove setAccessible() call

### DIFF
--- a/src/DatabaseTestingExtension.php
+++ b/src/DatabaseTestingExtension.php
@@ -65,7 +65,6 @@ final class DatabaseTestingExtension implements Extension {
                     $testDatabaseReflection = new \ReflectionClass(TestDatabase::class);
                     $testDatabase = $testDatabaseReflection->newInstanceWithoutConstructor();
                     $constructor = $testDatabaseReflection->getConstructor();
-                    $constructor->setAccessible(true);
                     $constructor->invoke($testDatabase, $this->data->connectionAdapter);
 
                     foreach ($reflection->getProperties() as $reflectionProperty) {


### PR DESCRIPTION
No longer needed since PHP 8.1, deprecated in PHP 8.5